### PR TITLE
Fix/keep names upstream

### DIFF
--- a/.changeset/new-bags-hear.md
+++ b/.changeset/new-bags-hear.md
@@ -1,5 +1,0 @@
----
-"monimejs": patch
----
-
-Fix error logs showing minified code by adding --keep-names to esbuild build


### PR DESCRIPTION

## Changes

- Add `--keep-names` flag to esbuild build command in [package.json](cci:7://file:///home/emmanuel/work/fun/monimejs/package.json:0:0-0:0)
- Add test script [scripts/test-error-names.mjs](cci:7://file:///home/emmanuel/work/fun/monimejs/scripts/test-error-names.mjs:0:0-0:0) to verify error names

## Bundle Size Impact

- Before: 20.0kb
- After: 20.8kb (+0.8kb, a slight increase)

The slight bundle size increase is worth the improved debugging experience.

## Testing

```bash
npm run build
node scripts/test-error-names.mjs