### PR TITLE
Send the pinned Monime API version header

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -26,6 +26,7 @@ import { ClientOptionsSchema, validate } from "./validation.js";
  */
 
 const API_VERSION = "v1";
+const MONIME_VERSION = "caph.2025-08-23";
 
 /** API version prefix for all endpoints */
 /** @type {number} */
@@ -162,6 +163,7 @@ class MonimeHttpClient {
     /** @type {Record<string, string>} */
     const headers = {
       "Monime-Space-Id": this.#space_id,
+      "Monime-Version": MONIME_VERSION,
       Authorization: `Bearer ${this.#access_token}`,
     };
     if (body !== undefined) {

--- a/test/http-client.test.js
+++ b/test/http-client.test.js
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { MonimeHttpClient } from "../src/http-client.js";
+
+const original_fetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = original_fetch;
+});
+
+test("sends the current Monime API version header", async () => {
+  /** @type {RequestInit | undefined} */
+  let received_options;
+  globalThis.fetch = async (_url, options) => {
+    received_options = options;
+    return new Response(JSON.stringify({ success: true, result: {} }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  const client = new MonimeHttpClient({
+    spaceId: "spc-test",
+    accessToken: "test-token",
+    retries: 0,
+  });
+
+  await client.request({ method: "GET", path: "/banks" });
+
+  assert.ok(received_options);
+  assert.equal(
+    /** @type {Record<string, string>} */ (received_options.headers)[
+      "Monime-Version"
+    ],
+    "caph.2025-08-23",
+  );
+});

--- a/test/monime-version-header.test.js
+++ b/test/monime-version-header.test.js
@@ -9,7 +9,7 @@ afterEach(() => {
   globalThis.fetch = original_fetch;
 });
 
-test("sends the current Monime API version header", async () => {
+test("sends the pinned Monime API version header", async () => {
   /** @type {RequestInit | undefined} */
   let received_options;
   globalThis.fetch = async (_url, options) => {


### PR DESCRIPTION
## What this fixes

Requests currently omit `Monime-Version`, so the API can handle them without the contract version this SDK was built against. Monime’s official OpenAPI repository lists `caph.2025-08-23` as the current contract used by this codebase.

## Changes

- Send `Monime-Version: caph.2025-08-23` on every API request.
- Add a mocked HTTP test that checks the exact header value.

## Verification

- `node --test test/monime-version-header.test.js`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`