### PR TITLE
Correct invalid SDK examples

### DIFF
--- a/docs/examples/internal-transfer.md
+++ b/docs/examples/internal-transfer.md
@@ -87,7 +87,7 @@ const { success, result } = await client.internalTransfer.update(transferId, {
 Cancel and remove a transfer. Can only delete if not yet processed.
 
 ```javascript
-const { success, success } = await client.internalTransfer.delete(transferId);
+const { success } = await client.internalTransfer.delete(transferId);
 ```
 
 

--- a/docs/examples/payment-code.md
+++ b/docs/examples/payment-code.md
@@ -84,7 +84,7 @@ List only recurrent payment codes for subscription and installment management.
 ```javascript
 const { success, result } = await client.paymentCode.list({
   mode: "recurrent",
-  limit: 100,
+  limit: 50,
 });
 ```
 

--- a/docs/examples/receipt.md
+++ b/docs/examples/receipt.md
@@ -18,7 +18,7 @@ Redeem all available entitlements on a receipt at once.
 const { success, result } = await client.receipt.redeem(
   "ORDER-12345",
   { redeemAll: true },
-  "unique-idempotency-key-001",
+  { idempotencyKey: "unique-idempotency-key-001" },
 );
 ```
 
@@ -35,7 +35,7 @@ const { success, result } = await client.receipt.redeem(
       { key: "voucher-drink", units: 1 },
     ],
   },
-  "unique-idempotency-key-002",
+  { idempotencyKey: "unique-idempotency-key-002" },
 );
 ```
 
@@ -49,7 +49,7 @@ const { success, result } = await client.receipt.redeem(
   {
     entitlements: [{ key: "ticket-vip" }],
   },
-  "unique-idempotency-key-003",
+  { idempotencyKey: "unique-idempotency-key-003" },
 );
 ```
 
@@ -69,6 +69,6 @@ const { success, result } = await client.receipt.redeem(
       timestamp: new Date().toISOString(),
     },
   },
-  "unique-idempotency-key-004",
+  { idempotencyKey: "unique-idempotency-key-004" },
 );
 ```


### PR DESCRIPTION
## What this fixes

Three examples do not match the SDK contract and cannot be copied as written.

## Changes

- Pass receipt idempotency keys through `RequestConfig`.
- Remove duplicate `success` destructuring from the internal transfer delete example.
- Change the payment code list limit from 100 to the supported maximum of 50.

## Verification

- `npm run typecheck`
- `npm run format:check`
- `git diff --check`