### PR TITLE
Declare every MonimeClient module contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "format": "biome check --write .",
     "format:check": "biome check .",
     "typecheck": "tsc --noEmit",
+    "typecheck:contracts": "tsc --project tsconfig.types-contract.json",
     "build": "npm run build:js && npm run build:types",
     "build:js": "esbuild src/index.js --bundle --format=esm --outfile=dist/index.js --target=node20 --minify --tree-shaking=true --external:valibot",
     "build:types": "cp src/index.d.ts dist/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1538,6 +1538,197 @@ export type GetProviderKycParams = {
   accountId: string;
 };
 
+declare class BankModule {
+  list(
+    params: ListBanksParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<Bank>>;
+  get(providerId: string, config?: RequestConfig): Promise<ApiResponse<Bank>>;
+}
+
+declare class CheckoutSessionModule {
+  create(
+    input: CreateCheckoutSessionInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<CheckoutSession>>;
+  get(
+    id: string,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<CheckoutSession>>;
+  list(
+    params?: ListCheckoutSessionsParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<CheckoutSession>>;
+  delete(id: string, config?: RequestConfig): Promise<ApiDeleteResponse>;
+}
+
+declare class FinancialAccountModule {
+  create(
+    input: CreateFinancialAccountInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<FinancialAccount>>;
+  get(
+    id: string,
+    params?: GetFinancialAccountParams,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<FinancialAccount>>;
+  list(
+    params?: ListFinancialAccountsParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<FinancialAccount>>;
+  update(
+    id: string,
+    input: UpdateFinancialAccountInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<FinancialAccount>>;
+}
+
+declare class FinancialTransactionModule {
+  get(
+    id: string,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<FinancialTransaction>>;
+  list(
+    params?: ListFinancialTransactionsParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<FinancialTransaction>>;
+}
+
+declare class InternalTransferModule {
+  create(
+    input: CreateInternalTransferInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<InternalTransfer>>;
+  get(
+    id: string,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<InternalTransfer>>;
+  list(
+    params?: ListInternalTransfersParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<InternalTransfer>>;
+  update(
+    id: string,
+    input: UpdateInternalTransferInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<InternalTransfer>>;
+  delete(id: string, config?: RequestConfig): Promise<ApiDeleteResponse>;
+}
+
+declare class MomoModule {
+  list(
+    params: ListMomosParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<Momo>>;
+  get(providerId: string, config?: RequestConfig): Promise<ApiResponse<Momo>>;
+}
+
+declare class PaymentCodeModule {
+  create(
+    input: CreatePaymentCodeInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<PaymentCode>>;
+  get(id: string, config?: RequestConfig): Promise<ApiResponse<PaymentCode>>;
+  list(
+    params?: ListPaymentCodesParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<PaymentCode>>;
+  update(
+    id: string,
+    input: UpdatePaymentCodeInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<PaymentCode>>;
+  delete(id: string, config?: RequestConfig): Promise<ApiDeleteResponse>;
+}
+
+declare class PaymentModule {
+  get(id: string, config?: RequestConfig): Promise<ApiResponse<Payment>>;
+  list(
+    params?: ListPaymentsParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<Payment>>;
+  update(
+    id: string,
+    input: UpdatePaymentInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<Payment>>;
+}
+
+declare class PayoutModule {
+  create(
+    input: CreatePayoutInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<Payout>>;
+  get(id: string, config?: RequestConfig): Promise<ApiResponse<Payout>>;
+  list(
+    params?: ListPayoutsParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<Payout>>;
+  update(
+    id: string,
+    input: UpdatePayoutInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<Payout>>;
+  delete(id: string, config?: RequestConfig): Promise<ApiDeleteResponse>;
+}
+
+declare class ProviderKycModule {
+  get(
+    providerId: string,
+    params: GetProviderKycParams,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<ProviderKyc>>;
+}
+
+declare class ReceiptModule {
+  get(
+    orderNumber: string,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<Receipt>>;
+  redeem(
+    orderNumber: string,
+    input: RedeemReceiptInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<RedeemReceiptResult>>;
+}
+
+declare class UssdOtpModule {
+  create(
+    input: CreateUssdOtpInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<UssdOtp>>;
+  get(id: string, config?: RequestConfig): Promise<ApiResponse<UssdOtp>>;
+  list(
+    params?: ListUssdOtpsParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<UssdOtp>>;
+  delete(id: string, config?: RequestConfig): Promise<ApiDeleteResponse>;
+}
+
+declare class WebhookModule {
+  create(
+    input: CreateWebhookInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<Webhook>>;
+  get(id: string, config?: RequestConfig): Promise<ApiResponse<Webhook>>;
+  list(
+    params?: ListWebhooksParams,
+    config?: RequestConfig,
+  ): Promise<ApiListResponse<Webhook>>;
+  update(
+    id: string,
+    input: UpdateWebhookInput,
+    config?: RequestConfig,
+  ): Promise<ApiResponse<Webhook>>;
+  delete(id: string, config?: RequestConfig): Promise<ApiDeleteResponse>;
+  verifySignature(
+    rawBody: string | Buffer,
+    headers: Record<string, string>,
+    secretOrPublicKey: string,
+    options?: { toleranceSeconds?: number },
+  ): never;
+}
+
 export class MonimeClient {
   constructor(options: ClientOptions);
   readonly bank: BankModule;

--- a/test/types/client-modules.ts
+++ b/test/types/client-modules.ts
@@ -1,0 +1,98 @@
+import type {
+  ApiDeleteResponse,
+  ApiListResponse,
+  ApiResponse,
+  Bank,
+  CheckoutSession,
+  FinancialAccount,
+  FinancialTransaction,
+  InternalTransfer,
+  Momo,
+  MonimeClient,
+  Payment,
+  PaymentCode,
+  Payout,
+  ProviderKyc,
+  Receipt,
+  RedeemReceiptResult,
+  UssdOtp,
+  Webhook,
+} from "../../src/index.js";
+
+declare const client: MonimeClient;
+
+const bank_response: Promise<ApiResponse<Bank>> = client.bank.get("m17");
+const bank_list_response: Promise<ApiListResponse<Bank>> = client.bank.list({
+  country: "SL",
+});
+const checkout_response: Promise<ApiResponse<CheckoutSession>> =
+  client.checkoutSession.create({
+    name: "Order",
+    lineItems: [],
+  });
+const checkout_delete_response: Promise<ApiDeleteResponse> =
+  client.checkoutSession.delete("cs-1");
+const account_response: Promise<ApiResponse<FinancialAccount>> =
+  client.financialAccount.get("fa-1", { withBalance: true });
+const transaction_response: Promise<ApiResponse<FinancialTransaction>> =
+  client.financialTransaction.get("txn-1");
+const transfer_response: Promise<ApiResponse<InternalTransfer>> =
+  client.internalTransfer.update("trn-1", { description: "Reserve" });
+const momo_response: Promise<ApiResponse<Momo>> = client.momo.get("m17");
+const payment_code_response: Promise<ApiResponse<PaymentCode>> =
+  client.paymentCode.create({
+    name: "Order",
+  });
+const payment_response: Promise<ApiResponse<Payment>> = client.payment.update(
+  "pay-1",
+  {
+    name: "Order",
+  },
+);
+const payout_response: Promise<ApiResponse<Payout>> = client.payout.create({
+  amount: { currency: "SLE", value: 100 },
+  destination: { type: "momo", providerId: "m17", phoneNumber: "23200000000" },
+});
+const provider_kyc_response: Promise<ApiResponse<ProviderKyc>> =
+  client.providerKyc.get("m17", {
+    accountId: "23200000000",
+  });
+const receipt_response: Promise<ApiResponse<Receipt>> =
+  client.receipt.get("order-1");
+const redemption_response: Promise<ApiResponse<RedeemReceiptResult>> =
+  client.receipt.redeem("order-1", { redeemAll: true });
+const ussd_otp_response: Promise<ApiResponse<UssdOtp>> = client.ussdOtp.create({
+  authorizedPhoneNumber: "23200000000",
+});
+const webhook_response: Promise<ApiResponse<Webhook>> = client.webhook.update(
+  "whk-1",
+  {
+    enabled: true,
+  },
+);
+const webhook_verification: never = client.webhook.verifySignature(
+  "body",
+  { "monime-signature": "signature" },
+  "secret",
+  { toleranceSeconds: 300 },
+);
+
+void [
+  bank_response,
+  bank_list_response,
+  checkout_response,
+  checkout_delete_response,
+  account_response,
+  transaction_response,
+  transfer_response,
+  momo_response,
+  payment_code_response,
+  payment_response,
+  payout_response,
+  provider_kyc_response,
+  receipt_response,
+  redemption_response,
+  ussd_otp_response,
+  webhook_response,
+  webhook_verification,
+];

--- a/tsconfig.types-contract.json
+++ b/tsconfig.types-contract.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "checkJs": false,
+    "noEmit": true
+  },
+  "include": ["src/index.d.ts", "test/types/**/*.ts"]
+}


### PR DESCRIPTION
## What this fixes

`MonimeClient` referenced module types that were never declared. TypeScript consumers could not reliably compile calls through most client properties even though those modules exist at runtime.

## Changes

- Declare all module contracts used by `MonimeClient`.
- Match each declaration to its runtime method signatures and existing request and response types.
- Keep module classes internal because the package does not export them at runtime.
- Add a compiler fixture that exercises every module.

## Verification

- `npm run typecheck:contracts`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`