### PR TITLE
Handle successful responses with no body

### DIFF
--- a/src/http-client.js
+++ b/src/http-client.js
@@ -256,7 +256,9 @@ class MonimeHttpClient {
       });
       let data;
       try {
-        data = await res.json();
+        const response_text = await res.text();
+        data =
+          response_text.length === 0 ? undefined : JSON.parse(response_text);
       } catch {
         throw new MonimeApiError(
           `Invalid JSON response from server: ${res.status} ${res.statusText}`,
@@ -268,7 +270,7 @@ class MonimeHttpClient {
       if (!res.ok) {
         const retry_after = this.#parse_retry_after(res.headers);
         const error_response = /** @type {ApiErrorResponse} */ (data);
-        if (error_response.error) {
+        if (error_response?.error) {
           throw new MonimeApiError(
             error_response.error.message,
             error_response.error.code,
@@ -284,6 +286,9 @@ class MonimeHttpClient {
           [],
           retry_after,
         );
+      }
+      if (data === undefined) {
+        return /** @type {T} */ ({ success: true, messages: [] });
       }
       return /** @type {T} */ (data);
     } catch (error) {

--- a/test/empty-success-response.test.js
+++ b/test/empty-success-response.test.js
@@ -22,7 +22,7 @@ function mock_response(response) {
   globalThis.fetch = async () => response;
 }
 
-test("returns the delete response shape for a 204 response", async () => {
+test("returns the delete response shape for an empty 204 response", async () => {
   mock_response(new Response(null, { status: 204 }));
 
   const result = await create_client().request({

--- a/test/http-client.test.js
+++ b/test/http-client.test.js
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+
+import { MonimeApiError } from "../src/errors.js";
+import { MonimeHttpClient } from "../src/http-client.js";
+
+const original_fetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = original_fetch;
+});
+
+function create_client() {
+  return new MonimeHttpClient({
+    spaceId: "space-test",
+    accessToken: "token-test",
+    retries: 0,
+  });
+}
+
+function mock_response(response) {
+  globalThis.fetch = async () => response;
+}
+
+test("returns the delete response shape for a 204 response", async () => {
+  mock_response(new Response(null, { status: 204 }));
+
+  const result = await create_client().request({
+    method: "DELETE",
+    path: "/webhooks/whk-test",
+  });
+
+  assert.deepEqual(result, { success: true, messages: [] });
+});
+
+test("returns the delete response shape for an empty successful body", async () => {
+  mock_response(new Response("", { status: 200 }));
+
+  const result = await create_client().request({
+    method: "DELETE",
+    path: "/webhooks/whk-test",
+  });
+
+  assert.deepEqual(result, { success: true, messages: [] });
+});
+
+test("returns a normal JSON success response", async () => {
+  const response_body = {
+    success: true,
+    messages: [],
+    result: { id: "whk-test" },
+  };
+  mock_response(Response.json(response_body));
+
+  const result = await create_client().request({
+    method: "GET",
+    path: "/webhooks/whk-test",
+  });
+
+  assert.deepEqual(result, response_body);
+});
+
+test("rejects malformed non-empty JSON in a successful response", async () => {
+  mock_response(new Response("not-json", { status: 200 }));
+
+  await assert.rejects(
+    create_client().request({ method: "GET", path: "/webhooks/whk-test" }),
+    (error) => {
+      assert(error instanceof MonimeApiError);
+      assert.equal(error.code, 200);
+      assert.equal(error.reason, "invalid_json");
+      return true;
+    },
+  );
+});
+
+test("preserves a JSON API error response", async () => {
+  mock_response(
+    Response.json(
+      {
+        success: false,
+        messages: ["Webhook not found"],
+        error: {
+          code: 404,
+          reason: "not_found",
+          message: "Webhook not found",
+          details: [{ id: "whk-test" }],
+        },
+      },
+      { status: 404 },
+    ),
+  );
+
+  await assert.rejects(
+    create_client().request({ method: "GET", path: "/webhooks/whk-test" }),
+    (error) => {
+      assert(error instanceof MonimeApiError);
+      assert.equal(error.message, "Webhook not found");
+      assert.equal(error.code, 404);
+      assert.equal(error.reason, "not_found");
+      assert.deepEqual(error.details, [{ id: "whk-test" }]);
+      return true;
+    },
+  );
+});


### PR DESCRIPTION
## What this fixes

The HTTP client called `response.json()` for every response. Successful DELETE requests that returned 204 or an empty body therefore failed with an invalid JSON error.

## Changes

- Read the response body once and parse JSON only when content is present.
- Return the existing delete response shape for empty successful responses.
- Keep malformed non-empty JSON and API error responses visible as errors.

## Verification

- `node --test test/empty-success-response.test.js`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`