### PR TITLE
Send parsed validation output in request bodies

### DIFF
--- a/src/checkout-session.js
+++ b/src/checkout-session.js
@@ -47,13 +47,13 @@ class CheckoutSessionModule {
    * @throws {MonimeApiError} If the API returns an error
    */
   async create(input, config) {
-    if (this.#http_client.should_validate) {
-      validate(CreateCheckoutSessionInputSchema, input);
-    }
+    const validated_input = this.#http_client.should_validate
+      ? validate(CreateCheckoutSessionInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "POST",
       path: "/checkout-sessions",
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/src/financial-account.js
+++ b/src/financial-account.js
@@ -55,13 +55,13 @@ class FinancialAccountModule {
    * @throws {MonimeApiError} If the API returns an error
    */
   async create(input, config) {
-    if (this.#http_client.should_validate) {
-      validate(CreateFinancialAccountInputSchema, input);
-    }
+    const validated_input = this.#http_client.should_validate
+      ? validate(CreateFinancialAccountInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "POST",
       path: "/financial-accounts",
-      body: input,
+      body: validated_input,
       config,
     });
   }
@@ -130,12 +130,14 @@ class FinancialAccountModule {
   async update(id, input, config) {
     if (this.#http_client.should_validate) {
       validate(IdSchema, id);
-      validate(UpdateFinancialAccountInputSchema, input);
     }
+    const validated_input = this.#http_client.should_validate
+      ? validate(UpdateFinancialAccountInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "PATCH",
       path: `/financial-accounts/${encodeURIComponent(id)}`,
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/src/internal-transfer.js
+++ b/src/internal-transfer.js
@@ -54,13 +54,13 @@ class InternalTransferModule {
    * @throws {MonimeApiError} If the API returns an error
    */
   async create(input, config) {
-    if (this.#http_client.should_validate) {
-      validate(CreateInternalTransferInputSchema, input);
-    }
+    const validated_input = this.#http_client.should_validate
+      ? validate(CreateInternalTransferInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "POST",
       path: "/internal-transfers",
-      body: input,
+      body: validated_input,
       config,
     });
   }
@@ -123,12 +123,14 @@ class InternalTransferModule {
   async update(id, input, config) {
     if (this.#http_client.should_validate) {
       validate(IdSchema, id);
-      validate(UpdateInternalTransferInputSchema, input);
     }
+    const validated_input = this.#http_client.should_validate
+      ? validate(UpdateInternalTransferInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "PATCH",
       path: `/internal-transfers/${encodeURIComponent(id)}`,
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/src/payment-code.js
+++ b/src/payment-code.js
@@ -48,13 +48,13 @@ class PaymentCodeModule {
    * @throws {MonimeApiError} If the API returns an error
    */
   async create(input, config) {
-    if (this.#http_client.should_validate) {
-      validate(CreatePaymentCodeInputSchema, input);
-    }
+    const validated_input = this.#http_client.should_validate
+      ? validate(CreatePaymentCodeInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "POST",
       path: "/payment-codes",
-      body: input,
+      body: validated_input,
       config,
     });
   }
@@ -116,12 +116,14 @@ class PaymentCodeModule {
   async update(id, input, config) {
     if (this.#http_client.should_validate) {
       validate(IdSchema, id);
-      validate(UpdatePaymentCodeInputSchema, input);
     }
+    const validated_input = this.#http_client.should_validate
+      ? validate(UpdatePaymentCodeInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "PATCH",
       path: `/payment-codes/${encodeURIComponent(id)}`,
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/src/payment.js
+++ b/src/payment.js
@@ -95,12 +95,14 @@ class PaymentModule {
   async update(id, input, config) {
     if (this.#http_client.should_validate) {
       validate(IdSchema, id);
-      validate(UpdatePaymentInputSchema, input);
     }
+    const validated_input = this.#http_client.should_validate
+      ? validate(UpdatePaymentInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "PATCH",
       path: `/payments/${encodeURIComponent(id)}`,
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/src/payout.js
+++ b/src/payout.js
@@ -49,13 +49,13 @@ class PayoutModule {
    * @throws {MonimeApiError} If the API returns an error
    */
   async create(input, config) {
-    if (this.#http_client.should_validate) {
-      validate(CreatePayoutInputSchema, input);
-    }
+    const validated_input = this.#http_client.should_validate
+      ? validate(CreatePayoutInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "POST",
       path: "/payouts",
-      body: input,
+      body: validated_input,
       config,
     });
   }
@@ -119,12 +119,14 @@ class PayoutModule {
   async update(id, input, config) {
     if (this.#http_client.should_validate) {
       validate(IdSchema, id);
-      validate(UpdatePayoutInputSchema, input);
     }
+    const validated_input = this.#http_client.should_validate
+      ? validate(UpdatePayoutInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "PATCH",
       path: `/payouts/${encodeURIComponent(id)}`,
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/src/receipt.js
+++ b/src/receipt.js
@@ -75,12 +75,14 @@ class ReceiptModule {
   async redeem(orderNumber, input, config) {
     if (this.#http_client.should_validate) {
       validate(ReceiptOrderNumberSchema, orderNumber);
-      validate(RedeemReceiptInputSchema, input);
     }
+    const validated_input = this.#http_client.should_validate
+      ? validate(RedeemReceiptInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "POST",
       path: `/receipts/${encodeURIComponent(orderNumber)}/redeem`,
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -3,7 +3,6 @@ import * as v from "valibot";
 /**
  * @template {v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>} T
  * @param {T} schema
- * @returns {v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>}
  */
 function optional_nullable(schema) {
   return v.optional(v.nullable(schema));

--- a/src/ussd-otp.js
+++ b/src/ussd-otp.js
@@ -52,13 +52,13 @@ class UssdOtpModule {
    * @throws {MonimeApiError} If the API returns an error
    */
   async create(input, config) {
-    if (this.#http_client.should_validate) {
-      validate(CreateUssdOtpInputSchema, input);
-    }
+    const validated_input = this.#http_client.should_validate
+      ? validate(CreateUssdOtpInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "POST",
       path: "/ussd-otps",
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/src/validation.js
+++ b/src/validation.js
@@ -74,6 +74,7 @@ function to_validation_error(issues) {
  * @template T - The expected type of valid data (inferred from schema)
  * @param {v.BaseSchema<unknown, T, v.BaseIssue<unknown>>} schema - A valibot schema to validate against
  * @param {unknown} data - Unknown input data to validate
+ * @returns {T} The parsed output produced by the schema
  * @throws {MonimeValidationError} If validation fails with details about validation issues
  */
 function validate(schema, data) {
@@ -81,6 +82,7 @@ function validate(schema, data) {
   if (!result.success) {
     throw to_validation_error(result.issues);
   }
+  return result.output;
 }
 
 export {

--- a/src/webhook.js
+++ b/src/webhook.js
@@ -54,13 +54,13 @@ class WebhookModule {
    * @deprecated - Create webhook from the dashboard instead. this is not guaranteed to work.
    */
   async create(input, config) {
-    if (this.#http_client.should_validate) {
-      validate(CreateWebhookInputSchema, input);
-    }
+    const validated_input = this.#http_client.should_validate
+      ? validate(CreateWebhookInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "POST",
       path: "/webhooks",
-      body: input,
+      body: validated_input,
       config,
     });
   }
@@ -119,12 +119,14 @@ class WebhookModule {
   async update(id, input, config) {
     if (this.#http_client.should_validate) {
       validate(IdSchema, id);
-      validate(UpdateWebhookInputSchema, input);
     }
+    const validated_input = this.#http_client.should_validate
+      ? validate(UpdateWebhookInputSchema, input)
+      : input;
     return this.#http_client.request({
       method: "PATCH",
       path: `/webhooks/${encodeURIComponent(id)}`,
-      body: input,
+      body: validated_input,
       config,
     });
   }

--- a/test/validated-output.test.js
+++ b/test/validated-output.test.js
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { afterEach, test } from "node:test";
+import * as v from "valibot";
+import { MonimeClient } from "../src/index.js";
+import { validate } from "../src/validation.js";
+
+const original_fetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = original_fetch;
+});
+
+test("validate returns transformed and defaulted schema output", () => {
+  const schema = v.object({
+    name: v.pipe(
+      v.string(),
+      v.transform((value) => value.trim()),
+    ),
+    enabled: v.optional(v.boolean(), true),
+  });
+
+  assert.deepEqual(validate(schema, { name: "  checkout  " }), {
+    name: "checkout",
+    enabled: true,
+  });
+});
+
+test("request bodies use parsed output instead of the original input", async () => {
+  /** @type {RequestInit | undefined} */
+  let captured_options;
+  globalThis.fetch = async (_url, options) => {
+    captured_options = options;
+    return new Response(JSON.stringify({ success: true, result: {} }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  const client = new MonimeClient({
+    spaceId: "space",
+    accessToken: "token",
+    retries: 0,
+  });
+  const input = {
+    name: "Account",
+    currency: "SLE",
+    discardedBySchema: "must not reach fetch",
+  };
+
+  await client.financialAccount.create(input);
+
+  assert.deepEqual(JSON.parse(String(captured_options?.body)), {
+    name: "Account",
+    currency: "SLE",
+  });
+  assert.equal(input.discardedBySchema, "must not reach fetch");
+});


### PR DESCRIPTION
## What this fixes

`validate()` checked input but discarded Valibot’s parsed output. Request methods then sent the original object, including fields the schema had removed and without any defaults or transformations applied by the schema.

## Changes

- Return parsed output from `validate()`.
- Use that output for validated POST and PATCH request bodies.
- Preserve the original input when validation is explicitly disabled.
- Add tests for transformed values, defaults, and unknown-field removal.

## Verification

- `node --test test/validated-output.test.js`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`