### PR TITLE
Update Valibot past GHSA-5qjj-4xww-7phc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "valibot": "^1.4.0"
+        "valibot": "^1.4.2"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
@@ -700,9 +700,9 @@
       "license": "MIT"
     },
     "node_modules/valibot": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.0.tgz",
-      "integrity": "sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "valibot": "^1.4.0"
+    "valibot": "^1.4.2"
   }
 }


### PR DESCRIPTION
## What this fixes

Valibot 1.4.0 is affected by GHSA-5qjj-4xww-7phc. Crafted record issue paths can make `flatten()` throw when they use inherited object property names.

## Changes

- Update Valibot to 1.4.2.
- Refresh the lockfile without changing other dependency versions.

## Verification

- `npm audit --omit=dev` reports zero vulnerabilities.
- `npm run typecheck`
- `npm run format:check`
- `npm run build`