### PR TITLE
Keep published stack traces readable

### DIFF
--- a/docs/FEATURE_REFERENCE.md
+++ b/docs/FEATURE_REFERENCE.md
@@ -302,7 +302,6 @@ esbuild src/index.ts \
   --format=esm \
   --outfile=dist/index.js \
   --target=node20 \
-  --minify \
   --tree-shaking=true \
   --external:valibot
 ```
@@ -310,7 +309,7 @@ esbuild src/index.ts \
 - **ESM only** - No CommonJS build
 - **Node 20+** - Required for `AbortSignal.any()`
 - **External valibot** - Not bundled, listed as dependency
-- **Minified** - 20.1KB output
+- **Readable output** - Preserves useful source lines in uncaught stack traces
 
 ### TypeScript Declaration Generation
 
@@ -381,7 +380,7 @@ Modules are instantiated once in `MonimeClient` constructor and reused for the c
 | `valibot` | Schema validation | ~10KB |
 
 **Build Output:**
-- `dist/index.js` - Minified bundle | 20.1KB
+- `dist/index.js` - Readable ESM bundle
 - `dist/index.d.ts` - Type declarations | Bundled single file
 
 **Dev dependencies:**

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "format:check": "biome check .",
     "typecheck": "tsc --noEmit",
     "build": "npm run build:js && npm run build:types",
-    "build:js": "esbuild src/index.js --bundle --format=esm --outfile=dist/index.js --target=node20 --minify --tree-shaking=true --external:valibot",
+    "build:js": "esbuild src/index.js --bundle --format=esm --outfile=dist/index.js --target=node20 --tree-shaking=true --external:valibot",
     "build:types": "cp src/index.d.ts dist/index.d.ts",
     "build:clean": "rm -rf dist && npm run build",
     "prepublishOnly": "npm run build:clean",


### PR DESCRIPTION
## What this fixes

The published bundle is minified onto one line. When Node prints an uncaught error, it includes the source line containing the throw. That source line is currently the entire SDK bundle, so a normal API error can dump thousands of characters before the useful stack trace.

## Changes

- Stop minifying the distributed Node.js bundle.
- Keep bundling and tree shaking unchanged.
- Update the build documentation.

The readable bundle is larger on disk, but this is a server-side SDK and the difference is small. Clear error output is more useful than saving a few compressed kilobytes.

## Verification

- `npm run typecheck`
- `npm run format:check`
- `npm run build:clean`
- Built output has 1,896 lines with a maximum line length of 288 characters.
- A mocked uncaught `MonimeApiError` prints the throw site and stack instead of the full bundle.

Closes #4.