### PR TITLE
Export a generic webhook event envelope

### DIFF
--- a/docs/examples/webhook.md
+++ b/docs/examples/webhook.md
@@ -1,6 +1,22 @@
-# Webhook Examples
+# Webhook examples
 
 Webhooks provide real-time event notifications to your server. Configure webhooks to receive instant updates on payments, payouts, checkout sessions, and other platform events. Choose between HMAC or ECDSA signature verification for security.
+
+## Webhook event type
+
+`WebhookEvent` describes the common webhook envelope. Pass the expected resource type as its generic argument when the event data is known.
+
+```typescript
+import type { PaymentCode, WebhookEvent } from "monimejs";
+
+type PaymentCodeWebhookEvent = WebhookEvent<PaymentCode>;
+
+function handlePaymentCodeEvent(payload: PaymentCodeWebhookEvent) {
+  console.log(payload.event.name, payload.data.status);
+}
+```
+
+The type describes the payload for TypeScript. It does not parse or verify incoming requests.
 
 ## create with HMAC verification
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -940,6 +940,25 @@ export type ListWebhooksParams = {
   after?: string;
 };
 
+/** Envelope sent by Monime for a webhook event. */
+export type WebhookEvent<TData = unknown> = {
+  /** API contract version used for this event */
+  apiVersion: string;
+  /** Event identity and delivery timestamp */
+  event: {
+    id: string;
+    name: string;
+    timestamp: string;
+  };
+  /** Monime object associated with the event */
+  object: {
+    id: string;
+    type: string;
+  };
+  /** Event-specific object data */
+  data: TData;
+};
+
 /**
  * Internal transfer processing states.
  * - "pending": Transfer created, awaiting processing


### PR DESCRIPTION
## What this adds

The SDK exposes resource types, but consumers currently have to write the outer Monime webhook payload shape themselves.

This PR adds one small generic type:

```ts
type PaymentCodeWebhookEvent = WebhookEvent<PaymentCode>;
```

`WebhookEvent<TData>` contains `apiVersion`, `event`, `object`, and `data`. The generic argument controls only the `data` field. It does not parse requests, verify signatures, or define event-specific aliases. Those can be added later if needed.

## Changes

- Export `WebhookEvent<TData = unknown>`.
- Add a short `WebhookEvent<PaymentCode>` example.

## Verification

- `npm run typecheck`
- `npm run format:check`
- `npm run build`

Closes #12.